### PR TITLE
Add a time-buffer for late-arriving events

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Messages are written to standard output following the Singer specification. The 
 
 ### Incremental
 
-Incremental replication works in conjunction with a state file to only extract new records each time the tap is invoked.
+Incremental replication works in conjunction with a state file to only extract new records each time the tap is invoked. Due to the possibility of late-arriving events (it can take up to 15 minutes for records to be available in Snowflake after they happen) there is a 20-minute time delay. This means that the tap will not attempt to pull records with event times sooner than 20 minutes before the current time.
 
 
 ## Tests


### PR DESCRIPTION
# Description of change
One of our analysts noticed that we were missing a small percentage of records from our DW as compared to our Amplitude Snowflake instance. After some digging, I have confirmed with an Amplitude support contact that events can take up to 15 minutes to arrive to Snowflake after they've occurred. This means that when tap-amplitude grabs the last 15 minutes worth of events based on the "event_time" it will miss some records by default.

The fix here is to add a 20-minute "buffer" to the incremental timestamp to eliminate the possibility of missing some events that arrived late.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
